### PR TITLE
Update docker-compose files to work with the new MinIO console

### DIFF
--- a/docker-compose-legacy.yml
+++ b/docker-compose-legacy.yml
@@ -85,13 +85,14 @@ services:
          - ${PWD}/persistent/miniodata:/data:cached
     ports:
          - "9000:9000"
+         - "9001:9001"
     networks:
       - host-net
       - esmero-net
     environment:
          MINIO_ACCESS_KEY: minio
          MINIO_SECRET_KEY: minio123
-    command: server /data
+    command: server /data --console-address ":9001"
 networks:
   host-net:
     driver: bridge

--- a/docker-compose-linux.yml
+++ b/docker-compose-linux.yml
@@ -97,13 +97,14 @@ services:
          - ${PWD}/persistent/miniodata:/data:cached
     ports:
          - "9000:9000"
+         - "9001:9001"
     networks:
       - host-net
       - esmero-net
     environment:
          MINIO_ACCESS_KEY: minio
          MINIO_SECRET_KEY: minio123
-    command: server /data
+    command: server /data --console-address ":9001"
 networks:
   host-net:
     driver: bridge

--- a/docker-compose-osx.yml
+++ b/docker-compose-osx.yml
@@ -97,13 +97,14 @@ services:
          - ${PWD}/persistent/miniodata:/data:cached
     ports:
          - "9000:9000"
+         - "9001:9001"
     networks:
       - host-net
       - esmero-net
     environment:
          MINIO_ACCESS_KEY: minio
          MINIO_SECRET_KEY: minio123
-    command: server /data
+    command: server /data --console-address ":9001"
 networks:
   host-net:
     driver: bridge


### PR DESCRIPTION
Open/bind port 9001 in Docker, and update the MinIO start command to use this port for the console interface.
